### PR TITLE
Simplify `Vec<AtomicU8>` instantiation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,9 @@ pub struct AtomicFilter<const N: usize, const K: usize> {
 
 impl<const N: usize, const K: usize> Default for AtomicFilter<N, K> {
     fn default() -> Self {
+
         AtomicFilter {
-            contents: Vec::from_iter((0..N).into_iter().map(|_| AtomicU8::new(0))),
+            contents: std::iter::repeat_with(|| AtomicU8::new(0)).take(N).collect()
         }
     }
 }


### PR DESCRIPTION
Simplifies how `AtomicFilter`s buffer is initialized

I'm not entirely sure why this is faster than the previous implementation but I know that `take(N)` implements `TrustedLen`, meaning Rust _should_ allocate `N` bytes in the heap directly and then just fill in the buffer by repeating `AtomicU8::new(0)`

# Benches

```
bloomfilter check true  time:   [780.19 ns 791.25 ns 801.40 ns]                                    
                        change: [-5.6915% -3.3538% -1.0505%] (p = 0.01 < 0.05)
                        Performance has improved.

bloomfilter check false time:   [244.05 ns 245.66 ns 247.41 ns]                                    
                        change: [-5.9025% -3.7320% -1.4339%] (p = 0.00 < 0.05)
                        Performance has improved.

bloomfilter insert      time:   [817.90 ns 832.62 ns 848.97 ns]                                
                        change: [-1.7316% +1.3227% +4.3645%] (p = 0.39 > 0.05)
                        No change in performance detected.
``` 